### PR TITLE
Remove accession from HTTP POST request

### DIFF
--- a/resource/src/main/java/org/nmdp/service/feature/resource/FeatureMixIn.java
+++ b/resource/src/main/java/org/nmdp/service/feature/resource/FeatureMixIn.java
@@ -37,7 +37,6 @@ public final class FeatureMixIn {
     public FeatureMixIn(final @JsonProperty("locus") String locus,
                         final @JsonProperty("term") String term,
                         final @JsonProperty("rank") int rank,
-                        final @JsonProperty("accession") long accession,
                         final @JsonProperty("sequence") String sequence) {
 
         // empty

--- a/resource/src/main/java/org/nmdp/service/feature/resource/FeatureRequest.java
+++ b/resource/src/main/java/org/nmdp/service/feature/resource/FeatureRequest.java
@@ -33,26 +33,23 @@ import com.wordnik.swagger.annotations.ApiModelProperty;
 /**
  * Feature request.
  */
-@ApiModel("Provide locus, term, rank, and accession or sequence to create an enumerated sequence feature.")
+@ApiModel("Provide locus, term, rank, and sequence to create an enumerated sequence feature.")
 @Immutable
 public final class FeatureRequest {
     private final String locus;
     private final String term;
     private final int rank;
-    private final long accession;
     private final String sequence;
 
     @JsonCreator
     public FeatureRequest(final @JsonProperty("locus") String locus,
                           final @JsonProperty("term") String term,
                           final @JsonProperty("rank") int rank,
-                          final @JsonProperty("accession") long accession,
                           final @JsonProperty("sequence") String sequence) {
 
         this.locus = locus;
         this.term = term;
         this.rank = rank;
-        this.accession = accession;
         this.sequence = sequence;
     }
 
@@ -70,11 +67,6 @@ public final class FeatureRequest {
     @ApiModelProperty(value="feature rank, must be at least 1", required=true)
     public int getRank() {
         return rank;
-    }
-
-    @ApiModelProperty("feature accession, if provided, must be at least 1")
-    public long getAccession() {
-        return accession;
     }
 
     @ApiModelProperty("feature sequence, in DNA alphabet")

--- a/resource/src/main/java/org/nmdp/service/feature/resource/FeatureResource.java
+++ b/resource/src/main/java/org/nmdp/service/feature/resource/FeatureResource.java
@@ -89,22 +89,8 @@ public final class FeatureResource {
         checkNotNull(featureRequest);
 
         if (logger.isTraceEnabled()) {
-            logger.warn("createFeature locus " + featureRequest.getLocus() + " term " + featureRequest.getTerm() + " rank " + featureRequest.getRank() + " accession " + featureRequest.getAccession() + " sequence " + featureRequest.getSequence());
+            logger.trace("createFeature locus " + featureRequest.getLocus() + " term " + featureRequest.getTerm() + " rank " + featureRequest.getRank() + " sequence " + featureRequest.getSequence());
         }
-
-        // todo: should this check accession < 1L instead?
-        if (!Long.valueOf(0L).equals(featureRequest.getAccession())) {
-            if (logger.isTraceEnabled()) {
-                logger.trace("getFeature locus " + featureRequest.getLocus() + " term " + featureRequest.getTerm() + " rank " + featureRequest.getRank() + " accession " + featureRequest.getAccession());
-            }
-            return featureService.getFeature(featureRequest.getLocus(), featureRequest.getTerm(), featureRequest.getRank(), featureRequest.getAccession());
-        }
-        else if (featureRequest.getSequence() != null) {
-            if (logger.isTraceEnabled()) {
-                logger.trace("createFeature locus " + featureRequest.getLocus() + " term " + featureRequest.getTerm() + " rank " + featureRequest.getRank() + " sequence " + featureRequest.getSequence());
-            }
-            return featureService.createFeature(featureRequest.getLocus(), featureRequest.getTerm(), featureRequest.getRank(), featureRequest.getSequence());
-        }
-        return null;
+        return featureService.createFeature(featureRequest.getLocus(), featureRequest.getTerm(), featureRequest.getRank(), featureRequest.getSequence());
     }
 }

--- a/resource/src/test/java/org/nmdp/service/feature/resource/FeatureMixInTest.java
+++ b/resource/src/test/java/org/nmdp/service/feature/resource/FeatureMixInTest.java
@@ -33,6 +33,6 @@ public final class FeatureMixInTest {
 
     @Test
     public void testConstructor() {
-        assertNotNull(new FeatureMixIn("locus", "term", 2, 42L, "ACTG"));
+        assertNotNull(new FeatureMixIn("locus", "term", 2, "ACTG"));
     }
 }

--- a/resource/src/test/java/org/nmdp/service/feature/resource/FeatureRequestTest.java
+++ b/resource/src/test/java/org/nmdp/service/feature/resource/FeatureRequestTest.java
@@ -36,7 +36,7 @@ public final class FeatureRequestTest {
 
     @Before
     public void setUp() {
-        featureRequest = new FeatureRequest("locus", "term", 2, 42L, "ACGT");
+        featureRequest = new FeatureRequest("locus", "term", 2, "ACGT");
     }
 
     @Test
@@ -49,7 +49,6 @@ public final class FeatureRequestTest {
         assertEquals("locus", featureRequest.getLocus());
         assertEquals("term", featureRequest.getTerm());
         assertEquals(2, featureRequest.getRank());
-        assertEquals(42L, featureRequest.getAccession());
         assertEquals("ACGT", featureRequest.getSequence());
     }
 }

--- a/resource/src/test/java/org/nmdp/service/feature/resource/FeatureResourceTest.java
+++ b/resource/src/test/java/org/nmdp/service/feature/resource/FeatureResourceTest.java
@@ -74,6 +74,7 @@ public final class FeatureResourceTest {
     @Test
     public void testGetFeatureMiss() {
         when(featureService.getFeature("locus", "term", 2, 42L)).thenReturn(null);
+        // todo: this should throw a 404
         assertNull(featureResource.getFeature("locus", "term", 2, 42L));
     }
 
@@ -83,19 +84,13 @@ public final class FeatureResourceTest {
     }
 
     @Test
-    public void testCreateFeatureInvalidFeatureRequest() {
-        assertNull(featureResource.createFeature(new FeatureRequest("locus", "term", 2, -1, null)));
-    }
-
-    @Test
-    public void testCreateFeatureValidAccession() {
-        when(featureService.getFeature("locus", "term", 2, 42L)).thenReturn(feature);
-        assertEquals(feature, featureResource.createFeature(new FeatureRequest("locus", "term", 2, 42L, null)));
+    public void testCreateFeatureNullSequence() {
+        assertNull(featureResource.createFeature(new FeatureRequest("locus", "term", 2, null)));
     }
 
     @Test
     public void testCreateFeatureValidSequence() {
         when(featureService.createFeature("locus", "term", 2, "ACGT")).thenReturn(feature);
-        assertEquals(feature, featureResource.createFeature(new FeatureRequest("locus", "term", 2, 0L, "ACGT")));
+        assertEquals(feature, featureResource.createFeature(new FeatureRequest("locus", "term", 2, "ACGT")));
     }
 }

--- a/tools/src/main/java/org/nmdp/service/feature/tools/FeatureTools.java
+++ b/tools/src/main/java/org/nmdp/service/feature/tools/FeatureTools.java
@@ -108,7 +108,7 @@ public final class FeatureTools implements Callable<Integer> {
                 }
                 else {
                     // locus, term, rank, sequence
-                    writeFeature(featureService.createFeature(new FeatureRequest(tokens[0], tokens[1], Integer.parseInt(tokens[2]), 0L, tokens[3])), writer);
+                    writeFeature(featureService.createFeature(new FeatureRequest(tokens[0], tokens[1], Integer.parseInt(tokens[2]), tokens[3])), writer);
                 }
                 lineNumber++;
             }


### PR DESCRIPTION
Using HTTP POST to retrieve features by accession, while convenient, is confusing from an API standpoint.
