### PR TITLE
return HTTP error codes on user input errors

### DIFF
--- a/dropwizard/src/main/java/org/nmdp/service/feature/dropwizard/FeatureApplication.java
+++ b/dropwizard/src/main/java/org/nmdp/service/feature/dropwizard/FeatureApplication.java
@@ -28,15 +28,12 @@ import javax.annotation.concurrent.Immutable;
 
 import com.fasterxml.jackson.databind.SerializationFeature;
 
-import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 
 import com.wordnik.swagger.config.SwaggerConfig;
 
 import com.wordnik.swagger.model.ApiInfo;
-
-import io.dropwizard.Application;
 
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
@@ -45,6 +42,8 @@ import org.nmdp.service.common.dropwizard.CommonServiceApplication;
 
 import org.nmdp.service.feature.Feature;
 
+import org.nmdp.service.feature.resource.UserInputExceptionMapper;
+import org.nmdp.service.feature.resource.ExceptionMapperModule;
 import org.nmdp.service.feature.service.impl.FeatureServiceModule;
 
 import org.nmdp.service.feature.resource.FeatureMixIn;
@@ -68,7 +67,7 @@ public final class FeatureApplication extends CommonServiceApplication<FeatureCo
 
     @Override
     public void runService(final FeatureConfiguration configuration, final Environment environment) throws Exception {
-        Injector injector = Guice.createInjector(new FeatureServiceModule());
+        Injector injector = Guice.createInjector(new FeatureServiceModule(), new ExceptionMapperModule());
 
         environment.healthChecks().register("feature", new HealthCheck() {
                 @Override
@@ -78,6 +77,7 @@ public final class FeatureApplication extends CommonServiceApplication<FeatureCo
             });
 
         environment.jersey().register(injector.getInstance(FeatureResource.class));
+        environment.jersey().register(injector.getInstance(UserInputExceptionMapper.class));
 
         environment.getObjectMapper()
             .enable(SerializationFeature.INDENT_OUTPUT)

--- a/resource/src/main/java/org/nmdp/service/feature/resource/ExceptionMapperModule.java
+++ b/resource/src/main/java/org/nmdp/service/feature/resource/ExceptionMapperModule.java
@@ -1,0 +1,20 @@
+package org.nmdp.service.feature.resource;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
+
+import javax.annotation.concurrent.Immutable;
+
+@Immutable
+public class ExceptionMapperModule extends AbstractModule {
+    @Override
+    protected void configure() {
+        // empty
+    }
+
+    @Provides
+    UserInputExceptionMapper createUserInputExceptionMapper(){
+        return new UserInputExceptionMapper();
+    }
+
+}

--- a/resource/src/main/java/org/nmdp/service/feature/resource/FeatureResource.java
+++ b/resource/src/main/java/org/nmdp/service/feature/resource/FeatureResource.java
@@ -22,6 +22,7 @@
 */
 package org.nmdp.service.feature.resource;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.List;
@@ -40,17 +41,13 @@ import javax.ws.rs.core.MediaType;
 
 import com.google.inject.Inject;
 
+import com.wordnik.swagger.annotations.*;
 import org.nmdp.service.feature.Feature;
 
 import org.nmdp.service.feature.service.FeatureService;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.wordnik.swagger.annotations.Api;
-import com.wordnik.swagger.annotations.ApiImplicitParam;
-import com.wordnik.swagger.annotations.ApiOperation;
-import com.wordnik.swagger.annotations.ApiParam;
 
 /**
  * Feature resource.
@@ -72,10 +69,26 @@ public final class FeatureResource {
 
     @GET
     @ApiOperation(value="Retrieve an enumerated sequence feature", response=Feature.class)
+    @ApiResponses(value = {
+            @ApiResponse(code=400, message="locus must be provided"),
+            @ApiResponse(code=400, message="term must be provided"),
+            @ApiResponse(code=400, message="rank must be provided and at least 1"),
+            @ApiResponse(code=400, message="accession must be provided and at least 1"),
+    })
     public Feature getFeatureByQuery(final @QueryParam("locus") @ApiParam("locus name or URI") String locus,
                                      final @QueryParam("term") @ApiParam("Sequence Ontology (SO) term name, accession, or URI") String term,
                                      final @QueryParam("rank") @ApiParam("feature rank, must be at least 1") int rank,
-                                     final @QueryParam("accession") @ApiParam("accession, must be at least 1") long accession) {
+                                     final @QueryParam("accession") @ApiParam("accession, must be at least 1") long accession)
+            throws UserInputException {
+
+        try {
+            checkNotNull(locus, "locus must be provided");
+            checkNotNull(term, "term must be provided");
+            checkArgument(rank > 0, "rank must be provided and at least 1");
+            checkArgument(accession > 0L, "accession must be provided and at least 1");
+        }catch (Exception ex){
+            throw new UserInputException(ex.getMessage(), ex);
+        }
 
         if (logger.isTraceEnabled()) {
             logger.trace("getFeature locus " + locus + " term " + term + " rank " + rank + " accession " + accession);
@@ -88,8 +101,15 @@ public final class FeatureResource {
     @POST
     @ApiOperation(value="Create an enumerated sequence feature", response=Feature.class)
     @ApiImplicitParam(paramType="body", dataType="FeatureRequest")
-    public Feature createFeature(final FeatureRequest featureRequest) {
-        checkNotNull(featureRequest);
+    @ApiResponses(value = {
+            @ApiResponse(code=400, message="a request body must be provided"),
+    })
+    public Feature createFeature(final FeatureRequest featureRequest) throws UserInputException {
+        try {
+            checkNotNull(featureRequest, "a request body must be provided");
+        }catch (NullPointerException ex){
+            throw new UserInputException(ex.getMessage(), ex);
+        }
 
         if (logger.isTraceEnabled()) {
             logger.trace("createFeature locus " + featureRequest.getLocus() + " term " + featureRequest.getTerm() + " rank " + featureRequest.getRank() + " sequence " + featureRequest.getSequence());
@@ -100,15 +120,34 @@ public final class FeatureResource {
     @GET
     @Path("{locus}")
     @ApiOperation(value="List the enumerated sequence features at a locus", response=Feature.class, responseContainer="List")
-    public List<Feature> listFeatures(final @PathParam("locus") @ApiParam("locus name or URI") String locus) {
+    @ApiResponses(value = {
+            @ApiResponse(code=400, message="locus must be provided"),
+    })
+    public List<Feature> listFeatures(final @PathParam("locus") @ApiParam("locus name or URI") String locus) throws UserInputException {
+        try {
+            checkNotNull(locus, "locus must be provided");
+        }catch (NullPointerException ex){
+            throw new UserInputException(ex.getMessage(), ex);
+        }
         return featureService.listFeatures(locus);
     }
 
     @GET
     @Path("{locus}/{term}")
     @ApiOperation(value="List the enumerated sequence features matching a term at a locus", response=Feature.class, responseContainer="List")
+    @ApiResponses(value = {
+            @ApiResponse(code=400, message="locus must be provided"),
+            @ApiResponse(code=400, message="term must be provided"),
+    })
     public List<Feature> listFeatures(final @PathParam("locus") @ApiParam("locus name or URI") String locus,
-                                      final @PathParam("term") @ApiParam("Sequence Ontology (SO) term name, accession, or URI") String term) {
+                                      final @PathParam("term") @ApiParam("Sequence Ontology (SO) term name, accession, or URI") String term)
+            throws UserInputException {
+        try {
+            checkNotNull(locus, "locus must be provided");
+            checkNotNull(term, "term must be provided");
+        }catch (NullPointerException ex){
+            throw new UserInputException(ex.getMessage(), ex);
+        }
 
         return featureService.listFeatures(locus, term);
     }
@@ -116,9 +155,21 @@ public final class FeatureResource {
     @GET
     @Path("{locus}/{term}/{rank}")
     @ApiOperation(value="List the enumerated sequence features matching a term and rank at a locus", response=Feature.class, responseContainer="List")
+    @ApiResponses(value = {
+            @ApiResponse(code=400, message="locus must be provided"),
+            @ApiResponse(code=400, message="term must be provided"),
+            @ApiResponse(code=400, message="rank must be provided and at least 1"),
+    })
     public List<Feature> listFeatures(final @PathParam("locus") @ApiParam("locus name or URI") String locus,
                                       final @PathParam("term") @ApiParam("Sequence Ontology (SO) term name, accession, or URI") String term,
-                                      final @PathParam("rank") @ApiParam("feature rank, must be at least 1") int rank) {
+                                      final @PathParam("rank") @ApiParam("feature rank, must be at least 1") int rank) throws UserInputException {
+        try {
+            checkNotNull(locus, "locus must be provided");
+            checkNotNull(term, "term must be provided");
+            checkArgument(rank > 0, "rank must be provided and at least 1");
+        }catch (Exception ex){
+            throw new UserInputException(ex.getMessage(), ex);
+        }
 
         return featureService.listFeatures(locus, term, rank);
     }
@@ -126,11 +177,25 @@ public final class FeatureResource {
     @GET
     @Path("{locus}/{term}/{rank}/{accession}")
     @ApiOperation(value="Retrieve an enumerated sequence feature", response=Feature.class)
+    @ApiResponses(value = {
+            @ApiResponse(code=400, message="locus must be provided"),
+            @ApiResponse(code=400, message="term must be provided"),
+            @ApiResponse(code=400, message="rank must be provided and at least 1"),
+            @ApiResponse(code=400, message="accession must be provided and at least 1"),
+    })
     public Feature getFeatureByPath(final @PathParam("locus") @ApiParam("locus name or URI") String locus,
                                     final @PathParam("term") @ApiParam("Sequence Ontology (SO) term name, accession, or URI") String term,
                                     final @PathParam("rank") @ApiParam("feature rank, must be at least 1") int rank,
-                                    final @PathParam("accession") @ApiParam("accession, must be at least 1") long accession) {
+                                    final @PathParam("accession") @ApiParam("accession, must be at least 1") long accession) throws UserInputException {
 
+        try {
+            checkNotNull(locus, "locus must be provided");
+            checkNotNull(term, "term must be provided");
+            checkArgument(rank > 0, "rank must be provided and at least 1");
+            checkArgument(accession > 0L, "accession must be provided and at least 1");
+        }catch (Exception ex){
+            throw new UserInputException(ex.getMessage(), ex);
+        }
         return featureService.getFeature(locus, term, rank, accession);
     }
 }

--- a/resource/src/main/java/org/nmdp/service/feature/resource/UserInputException.java
+++ b/resource/src/main/java/org/nmdp/service/feature/resource/UserInputException.java
@@ -1,0 +1,8 @@
+package org.nmdp.service.feature.resource;
+
+public class UserInputException extends Exception {
+
+    public UserInputException(String message, Throwable ex) {
+        super(message, ex);
+    }
+}

--- a/resource/src/main/java/org/nmdp/service/feature/resource/UserInputExceptionMapper.java
+++ b/resource/src/main/java/org/nmdp/service/feature/resource/UserInputExceptionMapper.java
@@ -1,0 +1,22 @@
+package org.nmdp.service.feature.resource;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+import java.util.HashMap;
+
+@Provider
+public class UserInputExceptionMapper implements ExceptionMapper<UserInputException> {
+
+    @Override
+    public Response toResponse(final UserInputException exception) {
+        return Response.status(Response.Status.BAD_REQUEST)
+                .entity(new HashMap<String, Object>(){{
+                    put("message", exception.getMessage());
+                    put("status", 400);
+                }})
+                .type(MediaType.APPLICATION_JSON_TYPE)
+                .build();
+    }
+}

--- a/resource/src/test/java/org/nmdp/service/feature/resource/FeatureResourceTest.java
+++ b/resource/src/test/java/org/nmdp/service/feature/resource/FeatureResourceTest.java
@@ -66,42 +66,42 @@ public final class FeatureResourceTest {
     }
 
     @Test
-    public void testGetFeatureByQuery() {
+    public void testGetFeatureByQuery() throws UserInputException {
         when(featureService.getFeature("locus", "term", 2, 42L)).thenReturn(feature);
         assertEquals(feature, featureResource.getFeatureByQuery("locus", "term", 2, 42L));
     }
 
     @Test
-    public void testGetFeatureByQueryMiss() {
+    public void testGetFeatureByQueryMiss() throws UserInputException {
         when(featureService.getFeature("locus", "term", 2, 42L)).thenReturn(null);
         // todo: this should throw a 404
         assertNull(featureResource.getFeatureByQuery("locus", "term", 2, 42L));
     }
 
     @Test
-    public void testGetFeatureByPath() {
+    public void testGetFeatureByPath() throws UserInputException {
         when(featureService.getFeature("locus", "term", 2, 42L)).thenReturn(feature);
         assertEquals(feature, featureResource.getFeatureByPath("locus", "term", 2, 42L));
     }
 
     @Test
-    public void testGetFeatureByPathMiss() {
+    public void testGetFeatureByPathMiss() throws UserInputException {
         when(featureService.getFeature("locus", "term", 2, 42L)).thenReturn(null);
         assertNull(featureResource.getFeatureByPath("locus", "term", 2, 42L));
     }
 
-    @Test(expected=NullPointerException.class)
-    public void testCreateFeatureNullFeatureRequest() {
+    @Test(expected=UserInputException.class)
+    public void testCreateFeatureNullFeatureRequest() throws UserInputException {
         featureResource.createFeature(null);
     }
 
     @Test
-    public void testCreateFeatureNullSequence() {
+    public void testCreateFeatureNullSequence() throws UserInputException {
         assertNull(featureResource.createFeature(new FeatureRequest("locus", "term", 2, null)));
     }
 
     @Test
-    public void testCreateFeatureValidSequence() {
+    public void testCreateFeatureValidSequence() throws UserInputException {
         when(featureService.createFeature("locus", "term", 2, "ACGT")).thenReturn(feature);
         assertEquals(feature, featureResource.createFeature(new FeatureRequest("locus", "term", 2, "ACGT")));
     }

--- a/service-impl/src/main/java/org/nmdp/service/feature/service/impl/FeatureServiceImpl.java
+++ b/service-impl/src/main/java/org/nmdp/service/feature/service/impl/FeatureServiceImpl.java
@@ -64,8 +64,8 @@ final class FeatureServiceImpl implements FeatureService {
                               final int rank,
                               final long accession) {
 
-        checkNotNull(locus);
-        checkNotNull(term);
+        checkNotNull(locus, "locus must be given");
+        checkNotNull(term, "term must be given");
         checkArgument(rank > 0, "rank must be at least 1");
         checkArgument(accession > 0L, "accession must be at least 1L");
         return features.get(locus, term, rank, accession);
@@ -77,10 +77,11 @@ final class FeatureServiceImpl implements FeatureService {
                                  final int rank,
                                  final String sequence) {
 
-        checkNotNull(locus);
-        checkNotNull(term);
+
+        checkNotNull(locus, "locus must be given");
+        checkNotNull(term, "term must be given");
         checkArgument(rank > 0, "rank must be at least 1");
-        checkNotNull(sequence);
+        checkNotNull(sequence, "sequence must be given");
         if (!sequencesToFeatures.containsKey(locus, term, rank)) {
             sequencesToFeatures.put(locus, term, rank, new SequencesToFeatures());
         }
@@ -89,7 +90,7 @@ final class FeatureServiceImpl implements FeatureService {
 
     @Override
     public List<Feature> listFeatures(final String locus) {
-        checkNotNull(locus);
+        checkNotNull(locus, "locus must be given");
         ArrayList<Feature> matchingFeatures = new ArrayList<Feature>();
         for (Feature feature : features.values()) {
             if (feature.getLocus().equals(locus)) {
@@ -102,8 +103,8 @@ final class FeatureServiceImpl implements FeatureService {
     @Override
     public List<Feature> listFeatures(final String locus,
                                       final String term) {
-        checkNotNull(locus);
-        checkNotNull(term);
+        checkNotNull(locus, "locus must be given");
+        checkNotNull(term, "term must be given");
         ArrayList<Feature> matchingFeatures = new ArrayList<Feature>();
         for (Feature feature : features.values()) {
             if (feature.getLocus().equals(locus) && feature.getTerm().equals(term)) {
@@ -117,8 +118,8 @@ final class FeatureServiceImpl implements FeatureService {
     public List<Feature> listFeatures(final String locus,
                                       final String term,
                                       final int rank) {
-        checkNotNull(locus);
-        checkNotNull(term);
+        checkNotNull(locus, "locus must be given");
+        checkNotNull(term, "term must be given");
         checkArgument(rank > 0, "rank must be at least 1");
         ArrayList<Feature> matchingFeatures = new ArrayList<Feature>();
         for (Feature feature : features.values()) {

--- a/service-jdbi/src/main/java/org/nmdp/service/feature/service/jdbi/JdbiFeatureService.java
+++ b/service-jdbi/src/main/java/org/nmdp/service/feature/service/jdbi/JdbiFeatureService.java
@@ -58,8 +58,8 @@ final class JdbiFeatureService implements FeatureService {
                               final int rank,
                               final long accession) {
 
-        checkNotNull(locus);
-        checkNotNull(term);
+        checkNotNull(locus, "locus must be given");
+        checkNotNull(term, "term must be given");
         checkArgument(rank > 0, "rank must be at least 1");
         checkArgument(accession > 0L, "accession must be at least 1L");
 
@@ -78,10 +78,10 @@ final class JdbiFeatureService implements FeatureService {
                                  final int rank,
                                  final String sequence) {
 
-        checkNotNull(locus);
-        checkNotNull(term);
+        checkNotNull(locus, "locus must be given");
+        checkNotNull(term, "term must be given");
         checkArgument(rank > 0, "rank must be at least 1");
-        checkNotNull(sequence);
+        checkNotNull(sequence, "sequence must be given");
 
         long locusId = featureDao.findLocusId(locus);
         long termId = featureDao.findTermId(term);
@@ -144,7 +144,7 @@ final class JdbiFeatureService implements FeatureService {
 
     @Override
     public List<Feature> listFeatures(final String locus) {
-        checkNotNull(locus);
+        checkNotNull(locus, "locus must be given");
         long locusId = featureDao.findLocusId(locus);
         return featureDao.listFeaturesByLocus(locusId);
     }
@@ -152,8 +152,8 @@ final class JdbiFeatureService implements FeatureService {
     @Override
     public List<Feature> listFeatures(final String locus,
                                       final String term) {
-        checkNotNull(locus);
-        checkNotNull(term);
+        checkNotNull(locus, "locus must be given");
+        checkNotNull(term, "term must be given");
         // todo: join in sql query
         long locusId = featureDao.findLocusId(locus);
         long termId = featureDao.findTermId(term);
@@ -164,8 +164,8 @@ final class JdbiFeatureService implements FeatureService {
     public List<Feature> listFeatures(final String locus,
                                       final String term,
                                       final int rank) {
-        checkNotNull(locus);
-        checkNotNull(term);
+        checkNotNull(locus, "locus must be given");
+        checkNotNull(term, "term must be given");
         checkArgument(rank > 0, "rank must be at least 1");
         long locusId = featureDao.findLocusId(locus);
         long termId = featureDao.findTermId(term);


### PR DESCRIPTION
Not null and basic value checks are now done in the feature resource, the common
API definition. Those unchecked exceptions are caught and wrapped into a custom
checked exception (`UserInputException`). This in turn is mapped to a `400`
response by the service.

This fixes nmdp-bioinformatics/service-feature#38
